### PR TITLE
Add Sigma CLI integration test

### DIFF
--- a/{{ cookiecutter.package_name }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/test.yml
@@ -38,3 +38,5 @@ jobs:
           label: Coverage
           message: {{ '${{ env.COVERAGE }}' }}
           color: {{ '${{ env.COVERAGE_COLOR }}' }}
+      - name: Run Sigma CLI integration test
+        run: sh 'tests/test_sigma_cli_integration_{{ cookiecutter.backend_package_name }}.sh'

--- a/{{ cookiecutter.package_name }}/tests/test_sigma_cli_integration_{{ cookiecutter.backend_package_name }}.sh
+++ b/{{ cookiecutter.package_name }}/tests/test_sigma_cli_integration_{{ cookiecutter.backend_package_name }}.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -e
+
+plugin="{{ cookiecutter.backend_package_name }}"
+
+# Ensure current environment is up-to-date
+poetry install
+poetry run pip install sigma-cli
+
+sigma=$(poetry run sigma version)
+
+# Fetch plugin metadata from sigma-cli
+# Relies on structured output from sigma-cli
+meta=$(poetry run sigma plugin list | grep "^| $plugin" | cat) # Avoid termination due to grep not matching
+if [ "$meta" = "" ]; then
+  echo "❌ FAIL: Could not find metadata for pySigma-backend-$plugin - check it appears in the plugin directory: https://github.com/SigmaHQ/pySigma-plugin-directory/"
+  exit 1
+fi
+echo "✅ PASS: pySigma-backend-$plugin was found in the plugin list"
+
+# Check that sigma-cli believes the plugin is compatible
+compatible=$(echo "$meta" | awk -F "|" '{print $6}' | awk '{$1=$1};1')
+if [ "$compatible" = "no" ]; then
+  echo "❌ FAIL: This version of pySigma-backend-$plugin is not compatible with the latest version of sigma-cli ($sigma) - the plugin directory may require updating: https://github.com/SigmaHQ/pySigma-plugin-directory/"
+  exit 2
+fi
+echo "✅ PASS: pySigma-backend-$plugin is compatible with the latest version of sigma-cli ($sigma)"
+
+# Check the plugin can be successfully installed
+install_logs=$(poetry run sigma plugin install "$plugin") 
+install_status=$(echo "$install_logs" | grep "Successfully installed plugin '$plugin'" | cat)
+if [ "$install_status" = "" ]; then
+  echo "❌ FAIL: Installing this version of pySigma-backend-$plugin was not successful. The install logs were:"
+  echo "$install_logs"
+  exit 3
+fi
+echo "✅ PASS: pySigma-backend-$plugin was successfully installed as a plugin"
+
+# Check the plugin can be used successfully to convert a simple rule
+# May need tweaking if the rule is not supported or really requires a pipeline
+convert_err=$(poetry run sigma convert -t $plugin --without-pipeline tests/test_sigma_rule.yml 2>&1  | grep "^Error: " | cat)
+if [ "$convert_err" != "" ]; then
+  echo "❌ FAIL: pySigma-backend-$plugin was not able to convert a simple test rule. The error message was:"
+  echo "$convert_err"
+  exit 4
+fi
+
+echo "✅ PASS: pySigma-backend-$plugin was able to convert a simple test rule"
+exit 0
+

--- a/{{ cookiecutter.package_name }}/tests/test_sigma_rule.yml
+++ b/{{ cookiecutter.package_name }}/tests/test_sigma_rule.yml
@@ -1,0 +1,14 @@
+title: Test Sigma File
+id: 324a02b6-9412-4cee-ad8a-580a5b233303
+status: test
+description: A testing file to check basic sigma conversion functionality
+references:
+  - https://github.com/SigmaHQ/sigma-specification/blob/main/Sigma_specification.md
+author: kelnage
+date: 2025-09-03
+logsource:
+  category: testing
+detection:
+  test:
+    file_name: field_value
+  condition: test


### PR DESCRIPTION
Adds a simple integration test for a backend, to ensure that the backend can be successfully installed into sigma-cli and can be used to convert a simple rule.